### PR TITLE
[DO NOT MERGE IT - INTERNAL REVIEW] Fix sample config and move it from wiki into code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You're in control:
 
 ## Configure automations
 
-Before installation we'll configure our automations, copy `./cloudfunctions/router/empty-config.yaml` to `./cloudfunctions/router/config.yaml`. You can also view a mostly filled out [sample configuration file](https://github.com/GoogleCloudPlatform/security-response-automation/wiki/Sample-configuration). Within this file we'll define a few steps to get started:
+Before installation we'll configure our automations, copy `./cloudfunctions/router/empty-config.yaml` to `./cloudfunctions/router/config.yaml`. You can also view a mostly filled out [sample configuration file](cloudfunctions/router/sample-config.yaml). Within this file we'll define a few steps to get started:
 
 - Which automations should apply to which findings.
 - Which projects to target these automations with and which to exclude.

--- a/cloudfunctions/router/sample-config.yaml
+++ b/cloudfunctions/router/sample-config.yaml
@@ -1,0 +1,140 @@
+# Config file example.
+# DO NOT CHANGE THE STRUCTURE OR THE INDENTATION OF THIS DOCUMENT.
+# All automations are in monitor mode (dry_run: true) enable the one you want.
+# Replace YOUR-ORGANIZATION-ID and YOUR-FOLDER-ID with the values used in the terraform script.
+# The excludes section:
+#          excludes:
+#            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+# It can be removed if all the projects inside the folder are to be affected by SRA.
+apiVersion: security-response-automation.cloud.google.com/v1alpha1
+kind: Remediation
+metadata:
+  name: router
+spec:
+  parameters:
+    # Event threat detection findings.
+    # https://cloud.google.com/security-command-center/docs/how-to-use-event-threat-detection
+    etd:
+      bad_ip:
+        # Create a snapshot of all the disks in a GCE instance.
+        - action: gce_create_disk_snapshot
+          # The `target` and `exclude` arrays accepts an ancestry pattern that is compared against the incoming project. 
+          # The target and exclude patterns are both considered however the excludes takes precedence. 
+          # The ancestry pattern allows you to specify granularity at the organization, folder and project levels.
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            # If dry_run: true, runs in monitor mode where changes are only logged and not performed.
+            dry_run: true
+            # Bad IP specific configuration.
+            # THIS PART IS OPTIONAL
+            gce_create_snapshot:
+              target_snapshot_project_id: target-projectid
+              target_snapshot_zone: us-central1-a
+      anomalous_iam:
+        - action: iam_revoke
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+            anomalous_iam:
+              allow_domains:
+                - google.com
+      ssh_brute_force:
+        - action: remediate_firewall
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+            open_firewall:
+              remediation_action: disable
+    # Security Health Analytics
+    sha:
+      public_bucket_acl:
+        - action: close_bucket
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      bucket_policy_only_disabled:
+        - action: enable_bucket_only_policy
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      public_sql_instance:
+        - action: close_cloud_sql
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      ssl_not_enforced:
+        - action: cloud_sql_require_ssl
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      sql_no_root_password:
+        - action: cloud_sql_update_password
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      public_ip_address:
+        - action: remove_public_ip
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      open_firewall:
+        - action: remediate_firewall
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+            open_firewall:
+              remediation_action: disable
+      bigquery_public_dataset:
+        - action: close_public_dataset
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      audit_logging_disabled:
+        - action: enable_audit_logs
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true
+      web_ui_enabled:
+        - action: disable_dashboard
+          target:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/*
+          excludes:
+            - organizations/YOUR-ORGANIZATION-ID/folders/YOUR-FOLDER-ID/projects/YOUR-PROJECT-TO-EXCLUDE
+          properties:
+            dry_run: true


### PR DESCRIPTION
This PR serves two purposes:

* It fixes a parsing error in the "open_firewall" property of the sample config file.

* It suggests to move the sample config file from wiki into code repository. Below I describe the motivations:
  - it is easier to evolve the file when it is in the same repository as the code, avoiding having it deprecated.
  - allow open-source contributions since GitHub does not allow PRs on wikis
  - enable forked projects to have the sample config file since GitHub wiki section is not copied into the forked project
